### PR TITLE
scale-invariant-objects: Objects classed `rigid = true` no parent scale.

### DIFF
--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -633,6 +633,21 @@ export default class DisplayObject extends EventEmitter
     {
         this._filters = value && value.slice();
     }
+
+    /**
+     * Sets rigidity of the DisplayObject. i.e. it cannot scale with it's parent.
+     *
+     * @member {boolean}
+     */
+    get rigid()
+    {
+        return this.transform.rigid;
+    }
+
+    set rigid(value) // eslint-disable-line require-jsdoc
+    {
+        this.transform.rigid = value;
+    }
 }
 
 // performance increase to avoid using call.. (10x faster)


### PR DESCRIPTION
- Needs testing on scales that are variable in x/y proportions.
     e.g. `x scale = 1` and `y scale = 1.4`
- Skew works, but might need more specific skew requirements test.
- Might be interesting to work out the scale reduction outside of
    `updateTransform`.

Fixes Issue: https://github.com/3stack-software/groundplan-editor-playground/issues/11
